### PR TITLE
temp quick fix to reorder the menu items in the backend

### DIFF
--- a/app/Resources/tools/install_scripts/AppKernelFragment.php
+++ b/app/Resources/tools/install_scripts/AppKernelFragment.php
@@ -1,14 +1,18 @@
         $bundles[] = new Kunstmaan\UtilitiesBundle\KunstmaanUtilitiesBundle();
-        // KunstmaanAdminBundle
-        $bundles[] = new FOS\UserBundle\FOSUserBundle();
-        $bundles[] = new Knp\Bundle\MenuBundle\KnpMenuBundle();
-        $bundles[] = new Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle();
-        $bundles[] = new Kunstmaan\AdminBundle\KunstmaanAdminBundle();
+        // KunstmaanNodeBundle
+        $bundles[] = new Kunstmaan\NodeBundle\KunstmaanNodeBundle();
+        $bundles[] = new Kunstmaan\SeoBundle\KunstmaanSeoBundle();
+        $bundles[] = new Symfony\Cmf\Bundle\RoutingExtraBundle\SymfonyCmfRoutingExtraBundle();
         // KunstmaanMediaBundle
         $bundles[] = new Stof\DoctrineExtensionsBundle\StofDoctrineExtensionsBundle();
         $bundles[] = new Liip\ImagineBundle\LiipImagineBundle();
         $bundles[] = new Knp\Bundle\GaufretteBundle\KnpGaufretteBundle();
         $bundles[] = new Kunstmaan\MediaBundle\KunstmaanMediaBundle();
+        // KunstmaanAdminBundle
+        $bundles[] = new FOS\UserBundle\FOSUserBundle();
+        $bundles[] = new Knp\Bundle\MenuBundle\KnpMenuBundle();
+        $bundles[] = new Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle();
+        $bundles[] = new Kunstmaan\AdminBundle\KunstmaanAdminBundle();
         // KunstmaanPagePartBundle
         $bundles[] = new Kunstmaan\PagePartBundle\KunstmaanPagePartBundle();
         // KunstmaanMediaPagePartBundle
@@ -18,10 +22,6 @@
         // KunstmaanAdminListBundle
         $bundles[] = new Kunstmaan\AdminListBundle\KunstmaanAdminListBundle();
         $bundles[] = new WhiteOctober\PagerfantaBundle\WhiteOctoberPagerfantaBundle();
-        // KunstmaanNodeBundle
-        $bundles[] = new Kunstmaan\NodeBundle\KunstmaanNodeBundle();
-        $bundles[] = new Kunstmaan\SeoBundle\KunstmaanSeoBundle();
-        $bundles[] = new Symfony\Cmf\Bundle\RoutingExtraBundle\SymfonyCmfRoutingExtraBundle();
         // KunstmaanGeneratorBundle
         $bundles[] = new Kunstmaan\GeneratorBundle\KunstmaanGeneratorBundle();
         // KunstmaanNewRelicBundle


### PR DESCRIPTION
Temporary fix for ordering the menu items in the top in the backend
