### PR TITLE
added required files for bower

### DIFF
--- a/app/Resources/tools/install_scripts/bower/.bowerrc
+++ b/app/Resources/tools/install_scripts/bower/.bowerrc
@@ -1,0 +1,3 @@
+{
+  "directory": "web/vendor/"
+}

--- a/app/Resources/tools/install_scripts/bower/bower.json
+++ b/app/Resources/tools/install_scripts/bower/bower.json
@@ -1,0 +1,15 @@
+{
+  "name": "frontendpoc",
+  "version": "0.1.0",
+  "dependencies": {
+    "sass-bootstrap": "~2.3.2",
+    "bourbon": "latest",
+    "cupcake": "git://github.com/Kunstmaan/cupcake.git",
+    "socialite": "git://github.com/dbushell/Socialite.git",
+    "jquery": "<2.0.0",
+    "flexslider": "latest",
+    "svgeezy": "latest",
+    "jquery-placeholder": "latest",
+    "flat-ui": "latest"
+  }
+}

--- a/app/Resources/tools/install_scripts/sandboxinstaller.rb
+++ b/app/Resources/tools/install_scripts/sandboxinstaller.rb
@@ -82,6 +82,15 @@ elsif command == "configure-bundles"
     params["multilanguage"] = false
     params["websitetitle"] = projectname.capitalize
     File.open(parametersymlpath, 'w') {|f| f.write(YAML.dump(parametersyml)) }
+elsif command == "configure-bower"
+    bower = ARGV[1]
+    projectname = ARGV[2]
+
+    # bower.json
+    buffer = open(bower).read
+    result = JSON.parse(buffer)
+    result['name'] = projectname
+    File.open(bower, 'w') {|f| f.write(JSON.pretty_generate(result)) }
 elsif command == "configure-multilanguage"
     parametersymlpath = ARGV[1]
     projectname = ARGV[2]


### PR DESCRIPTION
These files are required by the installer from the generator. Seeing in the installer it is going to use as version 2.3

example of the file needed:
https://raw.github.com/Kunstmaan/KunstmaanSandbox/2.3/app/Resources/tools/install_scripts/bower/.bowerrc
