### PR TITLE
Fix gitignore 23

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,6 @@ behat.yml
 .vagrant
 /cookbooks/
 /Cheffile.lock
-/composer.lock
 web/css
 /tmp/
 behat.yml

--- a/.gitignore
+++ b/.gitignore
@@ -20,9 +20,10 @@ behat.yml
 web/css
 /tmp/
 behat.yml
-web/app_dev.php
 .buildpath
 .project
 .settings/
 *.sublime-project
 *.sublime-workspace
+node_modules/
+web/vendor/

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ behat.yml
 *.sublime-workspace
 node_modules/
 web/vendor/
+web/app_dev.php


### PR DESCRIPTION
These same rules are applied to master. The oneliner pulls in this file for the new project and by default it'll include node_modules etc. Needs to be updated :)
