### PR TITLE
Behat multi single lang

### DIFF
--- a/app/Resources/tools/install_scripts/behat.yml-dist
+++ b/app/Resources/tools/install_scripts/behat.yml-dist
@@ -16,3 +16,8 @@ default:
     paths:
         features: features
         bootstrap: %behat.paths.features%/Context
+
+    context:
+        parameters:
+            multilanguage: %multilanguage%
+            language: '%language%'

--- a/app/Resources/tools/install_scripts/behat.yml-dist
+++ b/app/Resources/tools/install_scripts/behat.yml-dist
@@ -19,5 +19,4 @@ default:
 
     context:
         parameters:
-            multilanguage: %multilanguage%
-            language: '%language%'
+            language: '%multilanguage%'


### PR DESCRIPTION
use a context parameter to determine if the site is multi or single language in the behat tests.
